### PR TITLE
14 let select fetcher ignore own id for self referencing

### DIFF
--- a/src/components/form/form.helper.tsx
+++ b/src/components/form/form.helper.tsx
@@ -124,7 +124,7 @@ const TestComponent = ({
 }: {
   schema: BaseSchema;
   data: FetchDataType;
-  onSubmit: (e: React.FormEvent) => void;
+  onSubmit?: (e: React.FormEvent) => void;
 }) => {
   const components = createInputArray(schema, data);
   const routes = createMemoryRouter([

--- a/src/components/form/form.helper.tsx
+++ b/src/components/form/form.helper.tsx
@@ -36,11 +36,18 @@ const FixtureData = {
     title: "First Test",
     description: "First Test Description",
     studyId: ["studyId1"],
-    releaseDate: "2021-01-01T00:00:00Z",
+    releaseDate: "2021-01-01T00:00:00.000Z",
     deviceTypeId: "vocabularyId0",
-    createdAt: "2020-01-01T00:00:00",
-    updatedAt: "2020-01-02T00:00:00",
+    createdAt: "2020-01-01T00:00:00.000Z",
+    updatedAt: "2020-01-02T00:00:00.000Z",
     testId: ["testId1", "testId2"],
+  },
+  filledTestValue: {
+    title: "Fourth Test",
+    studyId: ["studyId0"],
+    study: "First Study",
+    testId: ["testId2"],
+    test: "Third Test",
   },
   study: [
     {

--- a/src/components/form/form.test.tsx
+++ b/src/components/form/form.test.tsx
@@ -49,6 +49,24 @@ const Action = {
       await userEvent.click(component);
     },
   },
+  enterTitleValue: async () => {
+    const titleComponent = document.querySelector(`input[name="title"]`);
+    await userEvent.type(titleComponent!, FixtureData.filledTestValue.title);
+  },
+  enterStudyValue: async () => {
+    const component = document.querySelectorAll(".SelectTrigger")[0];
+    await userEvent.click(component);
+    const label = Array.from(document.querySelectorAll(".SelectItem")).filter(
+      item => item.textContent === FixtureData.filledTestValue.study,
+    )[0];
+    await userEvent.click(label!);
+  },
+  enterTestValue: async () => {
+    const testTrigger = document.querySelectorAll(".SelectTrigger")[2];
+    await userEvent.click(testTrigger);
+    const label = screen.queryByText(FixtureData.filledTestValue.test);
+    await userEvent.click(label!);
+  },
 };
 
 const Validator = {
@@ -156,6 +174,33 @@ const Validator = {
       }
     },
   },
+  requiredFieldsStateInvalid: () => {
+    const titleComponent = document.querySelector(`input[name="title"]`);
+    expect(titleComponent).not.toBeNull();
+    expect(titleComponent?.getAttribute("data-valid")).toEqual("invalid");
+
+    const studyComponent = document.querySelectorAll(".SelectTrigger")[0];
+    expect(studyComponent).not.toBeUndefined();
+    expect(studyComponent.getAttribute("data-valid")).toEqual("invalid");
+
+    const testComponent = document.querySelectorAll(".SelectTrigger")[2];
+    expect(testComponent).not.toBeUndefined();
+    expect(testComponent.getAttribute("data-valid")).toEqual("invalid");
+  },
+  titleIsValid: () => {
+    const titleComponent = document.querySelector(`input[name="title"]`);
+    expect(titleComponent).not.toBeNull();
+    expect(titleComponent).not.toBeUndefined();
+    expect(titleComponent?.getAttribute("data-valid")).toBe("valid");
+  },
+  studyIsValid: () => {
+    const studyTrigger = document.querySelectorAll(".SelectTrigger")[0];
+    expect(studyTrigger.getAttribute("data-valid")).toBe("valid");
+  },
+  testIsValid: () => {
+    const testTrigger = document.querySelectorAll(".SelectTrigger")[2];
+    expect(testTrigger.getAttribute("data-valid")).toBe("valid");
+  },
 };
 
 describe("Test POST form", () => {
@@ -182,6 +227,41 @@ describe("Test POST form", () => {
     "Data are initially placeholders",
     Validator.data.isRenderedWithPlaceHolderValue,
   );
+  describe("When click on submit", () => {
+    beforeEach(Action.clickOnSubmit);
+    test("Form not submitted and required fields have invalid state", async () => {
+      expect(onSubmit).not.toBeCalled();
+      Validator.requiredFieldsStateInvalid();
+    });
+    test("Updating title makes it no longer invalid", async () => {
+      await Action.enterTitleValue();
+      Validator.titleIsValid();
+    });
+    test("Updating study makes it no longer invalid", async () => {
+      await Action.enterStudyValue();
+      Validator.studyIsValid();
+    });
+    test("Updating test makes it no longer invalid", async () => {
+      await Action.enterTestValue();
+      Validator.testIsValid();
+    });
+    test("Updating all fields allow form submission", async () => {
+      await Action.enterTitleValue();
+      await Action.enterStudyValue();
+      await Action.enterTestValue();
+      await Action.clickOnSubmit();
+      expect(onSubmit).toBeCalled();
+      expect(submissionValue["title"]).toEqual(
+        FixtureData.filledTestValue.title,
+      );
+      expect(submissionValue["studyId"]).toEqual(
+        FixtureData.filledTestValue.studyId,
+      );
+      expect(submissionValue["testId"]).toEqual(
+        FixtureData.filledTestValue.testId,
+      );
+    });
+  });
 });
 
 describe("Test PUT form", () => {

--- a/src/components/form/form.test.tsx
+++ b/src/components/form/form.test.tsx
@@ -11,11 +11,17 @@ import { beforeEach, describe, expect, test } from "vitest";
 
 const Action = {
   render: {
-    POST: () => {
-      render(<TestComponent schema={schema} data={null} />);
+    POST: (onSubmit?: (e: React.FormEvent<Element>) => void) => {
+      render(<TestComponent schema={schema} data={null} onSubmit={onSubmit} />);
     },
-    PUT: () => {
-      render(<TestComponent schema={schema} data={FixtureData.test} />);
+    PUT: (onSubmit?: (e: React.FormEvent<Element>) => void) => {
+      render(
+        <TestComponent
+          schema={schema}
+          data={FixtureData.test}
+          onSubmit={onSubmit}
+        />,
+      );
     },
   },
   clickOnDropDown: {


### PR DESCRIPTION
## Description

- Add excludeId prop for select component to allow it to ignore id (option no longer available and selectItem is hidden)
- factory method createInputArray automatically extract default data's id to use as exclude Id for select component.
- Tests were written and passed.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
